### PR TITLE
Give type access to manually implemented notifier futures

### DIFF
--- a/src/prod_cons/framed.rs
+++ b/src/prod_cons/framed.rs
@@ -10,7 +10,7 @@ use crate::{
         bbqhdl::BbqHandle,
         coordination::Coord,
         notifier::{
-            typed::{AsyncNotifierTyped, ConstrFnMut, ConstrFut, TypedWrapper},
+            typed::{AsyncNotifierTyped, ConstrFnMut, ConstrFut, Typed, TypedWrapper},
             AsyncNotifier, Notifier,
         },
         storage::Storage,
@@ -137,6 +137,15 @@ where
     }
 }
 
+impl<Q, S, C, N> Typed for FramedProducer<Q, S, C, N>
+where
+    S: Storage,
+    C: Coord,
+    N: Notifier,
+    Q: BbqHandle<S, C, N>,
+{
+}
+
 impl<Q, S, C, N, H> TypedWrapper<FramedProducer<Q, S, C, N, H>>
 where
     S: Storage,
@@ -227,6 +236,16 @@ where
     pub async fn wait_read(&self) -> FramedGrantR<Q, S, C, N, H> {
         self.bbq.not.wait_for_not_empty(|| self.read().ok()).await
     }
+}
+
+impl<Q, S, C, N, H> Typed for FramedConsumer<Q, S, C, N, H>
+where
+    S: Storage,
+    C: Coord,
+    N: AsyncNotifier,
+    Q: BbqHandle<S, C, N>,
+    H: LenHeader,
+{
 }
 
 impl<Q, S, C, N, H> TypedWrapper<FramedConsumer<Q, S, C, N, H>>

--- a/src/prod_cons/framed.rs
+++ b/src/prod_cons/framed.rs
@@ -10,7 +10,7 @@ use crate::{
         bbqhdl::BbqHandle,
         coordination::Coord,
         notifier::{
-            typed::{AsyncNotifierTyped, ConstrFnMut, ConstrFut, Typed, TypedWrapper},
+            typed::{AsyncNotifierTyped, BbqSync, ConstrFnMut, ConstrFut, Typed, TypedWrapper},
             AsyncNotifier, Notifier,
         },
         storage::Storage,
@@ -88,22 +88,16 @@ impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
 
 pub struct FramedProducer<Q, S, C, N, H = u16>
 where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
+    Self: BbqSync<Q, S, C, N>,
     H: LenHeader,
 {
-    bbq: Q::Target,
+    bbq: <Q as BbqHandle<S, C, N>>::Target,
     pd: PhantomData<(S, C, N, H)>,
 }
 
 impl<Q, S, C, N, H> FramedProducer<Q, S, C, N, H>
 where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
+    Self: BbqSync<Q, S, C, N>,
     H: LenHeader,
 {
     pub fn grant(&self, sz: H) -> Result<FramedGrantW<Q, S, C, N, H>, ()> {
@@ -137,14 +131,7 @@ where
     }
 }
 
-impl<Q, S, C, N> Typed for FramedProducer<Q, S, C, N>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-{
-}
+impl<Q, S, C, N> Typed for FramedProducer<Q, S, C, N> where Self: BbqSync<Q, S, C, N> {}
 
 impl<Q, S, C, N, H> TypedWrapper<FramedProducer<Q, S, C, N, H>>
 where

--- a/src/prod_cons/framed.rs
+++ b/src/prod_cons/framed.rs
@@ -10,7 +10,7 @@ use crate::{
         bbqhdl::BbqHandle,
         coordination::Coord,
         notifier::{
-            typed::{AsyncNotifierTyped, BbqSync, ConstrFnMut, ConstrFut, Typed, TypedWrapper},
+            typed::{AsyncNotifierTyped, ConstrFnMut, ConstrFut, Typed, TypedWrapper},
             AsyncNotifier, Notifier,
         },
         storage::Storage,
@@ -54,14 +54,14 @@ unsafe impl LenHeader for usize {
 }
 
 impl<S: Storage, C: Coord, N: Notifier> BBQueue<S, C, N> {
-    pub fn framed_producer(&self) -> FramedProducer<&'_ Self, S, C, N> {
+    pub fn framed_producer(&self) -> FramedProducer<&'_ Self> {
         FramedProducer {
             bbq: self.bbq_ref(),
             pd: PhantomData,
         }
     }
 
-    pub fn framed_consumer(&self) -> FramedConsumer<&'_ Self, S, C, N> {
+    pub fn framed_consumer(&self) -> FramedConsumer<&'_ Self> {
         FramedConsumer {
             bbq: self.bbq_ref(),
             pd: PhantomData,
@@ -71,14 +71,14 @@ impl<S: Storage, C: Coord, N: Notifier> BBQueue<S, C, N> {
 
 #[cfg(feature = "std")]
 impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
-    pub fn framed_producer(&self) -> FramedProducer<std::sync::Arc<BBQueue<S, C, N>>, S, C, N> {
+    pub fn framed_producer(&self) -> FramedProducer<Self> {
         FramedProducer {
             bbq: self.0.bbq_ref(),
             pd: PhantomData,
         }
     }
 
-    pub fn framed_consumer(&self) -> FramedConsumer<std::sync::Arc<BBQueue<S, C, N>>, S, C, N> {
+    pub fn framed_consumer(&self) -> FramedConsumer<Self> {
         FramedConsumer {
             bbq: self.0.bbq_ref(),
             pd: PhantomData,
@@ -86,21 +86,13 @@ impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
     }
 }
 
-pub struct FramedProducer<Q, S, C, N, H = u16>
-where
-    Self: BbqSync<Q, S, C, N>,
-    H: LenHeader,
-{
-    bbq: <Q as BbqHandle<S, C, N>>::Target,
-    pd: PhantomData<(S, C, N, H)>,
+pub struct FramedProducer<Q: BbqHandle, H = u16> {
+    bbq: Q::Target,
+    pd: PhantomData<H>,
 }
 
-impl<Q, S, C, N, H> FramedProducer<Q, S, C, N, H>
-where
-    Self: BbqSync<Q, S, C, N>,
-    H: LenHeader,
-{
-    pub fn grant(&self, sz: H) -> Result<FramedGrantW<Q, S, C, N, H>, ()> {
+impl<Q: BbqHandle, H: LenHeader> FramedProducer<Q, H> {
+    pub fn grant(&self, sz: H) -> Result<FramedGrantW<Q, H>, ()> {
         let (ptr, cap) = self.bbq.sto.ptr_len();
         let needed = sz.into() + core::mem::size_of::<H>();
 
@@ -118,58 +110,30 @@ where
     }
 }
 
-impl<Q, S, C, N, H> FramedProducer<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: AsyncNotifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
-    pub async fn wait_grant(&self, sz: H) -> FramedGrantW<Q, S, C, N, H> {
+impl<Q: BbqHandle<Notifier: AsyncNotifier>, H: LenHeader> FramedProducer<Q, H> {
+    pub async fn wait_grant(&self, sz: H) -> FramedGrantW<Q, H> {
         self.bbq.not.wait_for_not_full(|| self.grant(sz).ok()).await
     }
 }
 
-impl<Q, S, C, N> Typed for FramedProducer<Q, S, C, N> where Self: BbqSync<Q, S, C, N> {}
+impl<Q: BbqHandle, H: LenHeader> Typed for FramedProducer<Q, H> {}
 
-impl<Q, S, C, N, H> TypedWrapper<FramedProducer<Q, S, C, N, H>>
-where
-    S: Storage,
-    C: Coord,
-    N: AsyncNotifierTyped,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle<Notifier: AsyncNotifierTyped>, H: LenHeader> TypedWrapper<FramedProducer<Q, H>> {
     pub fn wait_grant(
         &self,
         sz: H,
-    ) -> <N as ConstrFut>::NotFull<impl ConstrFnMut<Out = FramedGrantW<Q, S, C, N, H>>> {
-        self.bbq.not.wait_for_not_full(move || self.grant(sz).ok())
+    ) -> <Q::Notifier as ConstrFut>::NotFull<impl ConstrFnMut<Out = FramedGrantW<Q, H>>> {
+        AsyncNotifierTyped::wait_for_not_full(&self.bbq.not, move || self.grant(sz).ok())
     }
 }
 
-pub struct FramedConsumer<Q, S, C, N, H = u16>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+pub struct FramedConsumer<Q: BbqHandle, H: LenHeader = u16> {
     bbq: Q::Target,
-    pd: PhantomData<(S, C, N, H)>,
+    pd: PhantomData<H>,
 }
 
-impl<Q, S, C, N, H> FramedConsumer<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
-    pub fn read(&self) -> Result<FramedGrantR<Q, S, C, N, H>, ()> {
+impl<Q: BbqHandle, H: LenHeader> FramedConsumer<Q, H> {
+    pub fn read(&self) -> Result<FramedGrantR<Q, H>, ()> {
         let (ptr, _cap) = self.bbq.sto.ptr_len();
         let (offset, grant_len) = self.bbq.cor.read()?;
 
@@ -212,65 +176,29 @@ where
     }
 }
 
-impl<Q, S, C, N, H> FramedConsumer<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: AsyncNotifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
-    pub async fn wait_read(&self) -> FramedGrantR<Q, S, C, N, H> {
+impl<Q: BbqHandle<Notifier: AsyncNotifier>, H: LenHeader> FramedConsumer<Q, H> {
+    pub async fn wait_read(&self) -> FramedGrantR<Q, H> {
         self.bbq.not.wait_for_not_empty(|| self.read().ok()).await
     }
 }
 
-impl<Q, S, C, N, H> Typed for FramedConsumer<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: AsyncNotifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
-}
+impl<Q: BbqHandle, H: LenHeader> Typed for FramedConsumer<Q, H> {}
 
-impl<Q, S, C, N, H> TypedWrapper<FramedConsumer<Q, S, C, N, H>>
-where
-    S: Storage,
-    C: Coord,
-    N: AsyncNotifierTyped,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle<Notifier: AsyncNotifierTyped>, H: LenHeader> TypedWrapper<FramedConsumer<Q, H>> {
     pub fn wait_read(
         &self,
-    ) -> <N as ConstrFut>::NotEmpty<impl ConstrFnMut<Out = FramedGrantR<Q, S, C, N, H>>> {
-        self.bbq.not.wait_for_not_empty(move || self.read().ok())
+    ) -> <Q::Notifier as ConstrFut>::NotEmpty<impl ConstrFnMut<Out = FramedGrantR<Q, H>>> {
+        AsyncNotifierTyped::wait_for_not_empty(&self.bbq.not, move || self.read().ok())
     }
 }
 
-pub struct FramedGrantW<Q, S, C, N, H = u16>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+pub struct FramedGrantW<Q: BbqHandle, H: LenHeader = u16> {
     bbq: Q::Target,
     base_ptr: NonNull<u8>,
     hdr: H,
 }
 
-impl<Q, S, C, N, H> Deref for FramedGrantW<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle, H: LenHeader> Deref for FramedGrantW<Q, H> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -283,14 +211,7 @@ where
     }
 }
 
-impl<Q, S, C, N, H> DerefMut for FramedGrantW<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle, H: LenHeader> DerefMut for FramedGrantW<Q, H> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         let len = self.hdr.into();
         let body_ptr = unsafe {
@@ -301,14 +222,7 @@ where
     }
 }
 
-impl<Q, S, C, N, H> Drop for FramedGrantW<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle, H: LenHeader> Drop for FramedGrantW<Q, H> {
     fn drop(&mut self) {
         // Default drop performs an "abort"
         let (_ptr, cap) = self.bbq.sto.ptr_len();
@@ -318,14 +232,7 @@ where
     }
 }
 
-impl<Q, S, C, N, H> FramedGrantW<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle, H: LenHeader> FramedGrantW<Q, H> {
     pub fn commit(self, used: H) {
         let (_ptr, cap) = self.bbq.sto.ptr_len();
         let hdrlen: usize = const { core::mem::size_of::<H>() };
@@ -351,27 +258,13 @@ where
     }
 }
 
-pub struct FramedGrantR<Q, S, C, N, H = u16>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+pub struct FramedGrantR<Q: BbqHandle, H: LenHeader> {
     bbq: Q::Target,
     body_ptr: NonNull<u8>,
     hdr: H,
 }
 
-impl<Q, S, C, N, H> Deref for FramedGrantR<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle, H: LenHeader> Deref for FramedGrantR<Q, H> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -380,42 +273,21 @@ where
     }
 }
 
-impl<Q, S, C, N, H> DerefMut for FramedGrantR<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle, H: LenHeader> DerefMut for FramedGrantR<Q, H> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         let len: usize = self.hdr.into();
         unsafe { core::slice::from_raw_parts_mut(self.body_ptr.as_ptr(), len) }
     }
 }
 
-impl<Q, S, C, N, H> Drop for FramedGrantR<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle, H: LenHeader> Drop for FramedGrantR<Q, H> {
     fn drop(&mut self) {
         // Default behavior is "keep" - release zero bytes
         self.bbq.cor.release_inner(0);
     }
 }
 
-impl<Q, S, C, N, H> FramedGrantR<Q, S, C, N, H>
-where
-    S: Storage,
-    C: Coord,
-    N: Notifier,
-    Q: BbqHandle<S, C, N>,
-    H: LenHeader,
-{
+impl<Q: BbqHandle, H: LenHeader> FramedGrantR<Q, H> {
     pub fn release(self) {
         let len: usize = self.hdr.into();
         let hdrlen: usize = const { core::mem::size_of::<H>() };

--- a/src/prod_cons/stream.rs
+++ b/src/prod_cons/stream.rs
@@ -10,7 +10,7 @@ use crate::{
         bbqhdl::BbqHandle,
         coordination::Coord,
         notifier::{
-            typed::{AsyncNotifierTyped, ConstrFnMut, ConstrFut, TypedWrapper},
+            typed::{AsyncNotifierTyped, ConstrFnMut, ConstrFut, Typed, TypedWrapper},
             AsyncNotifier, Notifier,
         },
         storage::Storage,
@@ -121,6 +121,15 @@ where
     }
 }
 
+impl<S, C, N, Q> Typed for StreamProducer<Q, S, C, N>
+where
+    S: Storage,
+    C: Coord,
+    N: Notifier,
+    Q: BbqHandle<S, C, N>,
+{
+}
+
 impl<Q, S, C, N> TypedWrapper<StreamProducer<Q, S, C, N>>
 where
     S: Storage,
@@ -191,6 +200,15 @@ where
     pub async fn wait_read(&self) -> StreamGrantR<Q, S, C, N> {
         self.bbq.not.wait_for_not_empty(|| self.read().ok()).await
     }
+}
+
+impl<S, C, N, Q> Typed for StreamConsumer<Q, S, C, N>
+where
+    S: Storage,
+    C: Coord,
+    N: Notifier,
+    Q: BbqHandle<S, C, N>,
+{
 }
 
 impl<Q, S, C, N> TypedWrapper<StreamConsumer<Q, S, C, N>>

--- a/src/traits/bbqhdl.rs
+++ b/src/traits/bbqhdl.rs
@@ -1,29 +1,56 @@
 use core::ops::Deref;
+use std::sync::Arc;
 
-use crate::queue::BBQueue;
+use crate::queue::{ArcBBQueue, BBQueue};
 
 use super::{coordination::Coord, notifier::Notifier, storage::Storage};
 
-pub trait BbqHandle<S: Storage, C: Coord, N: Notifier> {
-    type Target: Deref<Target = BBQueue<S, C, N>> + Clone;
+pub trait BbqHandle {
+    type Target: Deref<Target = BBQueue<Self::Storage, Self::Coord, Self::Notifier>> + Clone;
     fn bbq_ref(&self) -> Self::Target;
+
+    type Storage: Storage;
+    type Coord: Coord;
+    type Notifier: Notifier;
 }
 
-impl<'a, S: Storage, C: Coord, N: Notifier> BbqHandle<S, C, N> for &'a BBQueue<S, C, N> {
+impl<S: Storage, C: Coord, N: Notifier> BbqHandle for &BBQueue<S, C, N> {
     type Target = Self;
 
     #[inline(always)]
     fn bbq_ref(&self) -> Self::Target {
         *self
     }
+
+    type Storage = S;
+    type Coord = C;
+    type Notifier = N;
 }
 
 #[cfg(feature = "std")]
-impl<S: Storage, C: Coord, N: Notifier> BbqHandle<S, C, N> for std::sync::Arc<BBQueue<S, C, N>> {
-    type Target = std::sync::Arc<BBQueue<S, C, N>>;
+impl<S: Storage, C: Coord, N: Notifier> BbqHandle for ArcBBQueue<S, C, N> {
+    type Target = Arc<BBQueue<S, C, N>>;
+
+    #[inline(always)]
+    fn bbq_ref(&self) -> Self::Target {
+        self.0.clone()
+    }
+
+    type Storage = S;
+    type Coord = C;
+    type Notifier = N;
+}
+
+#[cfg(feature = "std")]
+impl<S: Storage, C: Coord, N: Notifier> BbqHandle for Arc<BBQueue<S, C, N>> {
+    type Target = Self;
 
     #[inline(always)]
     fn bbq_ref(&self) -> Self::Target {
         self.clone()
     }
+
+    type Storage = S;
+    type Coord = C;
+    type Notifier = N;
 }

--- a/src/traits/notifier/mod.rs
+++ b/src/traits/notifier/mod.rs
@@ -2,6 +2,7 @@
 pub mod maitake;
 
 pub mod blocking;
+pub mod typed;
 
 pub trait Notifier {
     const INIT: Self;

--- a/src/traits/notifier/typed.rs
+++ b/src/traits/notifier/typed.rs
@@ -1,4 +1,9 @@
-use crate::traits::notifier::{AsyncNotifier, Notifier};
+use crate::traits::{
+    bbqhdl::BbqHandle,
+    coordination::Coord,
+    notifier::{AsyncNotifier, Notifier},
+    storage::Storage,
+};
 use core::{future::Future, ops::Deref};
 
 pub trait AsyncNotifierTyped: Notifier {
@@ -47,6 +52,37 @@ where
     F: FnMut() -> Option<Out>,
 {
     type Out = Out;
+}
+
+#[allow(private_bounds)]
+pub trait BbqSync<Q, S, C, N>
+where
+    Self: Imply<S, Is: Storage>,
+    Self: Imply<C, Is: Coord>,
+    Self: Imply<N, Is: Notifier>,
+    Self: Imply<Q, Is: BbqHandle<S, C, N>>,
+{
+}
+
+impl<T, Q, S, C, N> BbqSync<Q, S, C, N> for T
+where
+    Self: Imply<S, Is: Storage>,
+    Self: Imply<C, Is: Coord>,
+    Self: Imply<N, Is: Notifier>,
+    Self: Imply<Q, Is: BbqHandle<S, C, N>>,
+{
+}
+
+pub(crate) trait Imply<T>: ImplyInner<T, Is = T> {}
+
+impl<S, T> Imply<T> for S {}
+
+pub(crate) trait ImplyInner<T> {
+    type Is;
+}
+
+impl<S, T> ImplyInner<T> for S {
+    type Is = T;
 }
 
 pub trait ConstrFut<'a>: AsyncNotifierTyped {

--- a/src/traits/notifier/typed.rs
+++ b/src/traits/notifier/typed.rs
@@ -1,9 +1,4 @@
-use crate::traits::{
-    bbqhdl::BbqHandle,
-    coordination::Coord,
-    notifier::{AsyncNotifier, Notifier},
-    storage::Storage,
-};
+use crate::traits::notifier::{AsyncNotifier, Notifier};
 use core::{future::Future, ops::Deref};
 
 pub trait AsyncNotifierTyped: Notifier {
@@ -52,37 +47,6 @@ where
     F: FnMut() -> Option<Out>,
 {
     type Out = Out;
-}
-
-#[allow(private_bounds)]
-pub trait BbqSync<Q, S, C, N>
-where
-    Self: Imply<S, Is: Storage>,
-    Self: Imply<C, Is: Coord>,
-    Self: Imply<N, Is: Notifier>,
-    Self: Imply<Q, Is: BbqHandle<S, C, N>>,
-{
-}
-
-impl<T, Q, S, C, N> BbqSync<Q, S, C, N> for T
-where
-    Self: Imply<S, Is: Storage>,
-    Self: Imply<C, Is: Coord>,
-    Self: Imply<N, Is: Notifier>,
-    Self: Imply<Q, Is: BbqHandle<S, C, N>>,
-{
-}
-
-pub(crate) trait Imply<T>: ImplyInner<T, Is = T> {}
-
-impl<S, T> Imply<T> for S {}
-
-pub(crate) trait ImplyInner<T> {
-    type Is;
-}
-
-impl<S, T> ImplyInner<T> for S {
-    type Is = T;
 }
 
 pub trait ConstrFut<'a>: AsyncNotifierTyped {

--- a/src/traits/notifier/typed.rs
+++ b/src/traits/notifier/typed.rs
@@ -28,8 +28,6 @@ pub trait Typed: Sized {
     }
 }
 
-impl<T> Typed for T {}
-
 pub struct TypedWrapper<T>(T);
 
 impl<T> Deref for TypedWrapper<T> {

--- a/src/traits/notifier/typed.rs
+++ b/src/traits/notifier/typed.rs
@@ -1,0 +1,65 @@
+use crate::traits::notifier::{AsyncNotifier, Notifier};
+use core::{future::Future, ops::Deref};
+
+pub trait AsyncNotifierTyped: Notifier {
+    type FutNotEmpty<F, T>: Future<Output = T>;
+    type FutNotFull<F, T>: Future<Output = T>;
+
+    fn wait_for_not_empty<T, F: FnMut() -> Option<T>>(&self, f: F) -> Self::FutNotEmpty<F, T>;
+    fn wait_for_not_full<T, F: FnMut() -> Option<T>>(&self, f: F) -> Self::FutNotFull<F, T>;
+}
+
+impl<N> AsyncNotifier for N
+where
+    N: AsyncNotifierTyped,
+{
+    async fn wait_for_not_empty<T, F: FnMut() -> Option<T>>(&self, f: F) -> T {
+        self.wait_for_not_empty(f).await
+    }
+
+    async fn wait_for_not_full<T, F: FnMut() -> Option<T>>(&self, f: F) -> T {
+        self.wait_for_not_full(f).await
+    }
+}
+
+pub trait Typed: Sized {
+    fn typed(self) -> TypedWrapper<Self> {
+        TypedWrapper(self)
+    }
+}
+
+impl<T> Typed for T {}
+
+pub struct TypedWrapper<T>(T);
+
+impl<T> Deref for TypedWrapper<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub trait ConstrFnMut<'a>: FnMut() -> Option<Self::Out> {
+    type Out;
+}
+
+impl<F, Out> ConstrFnMut<'_> for F
+where
+    F: FnMut() -> Option<Out>,
+{
+    type Out = Out;
+}
+
+pub trait ConstrFut<'a>: AsyncNotifierTyped {
+    type NotFull<F: ConstrFnMut<'a>>;
+    type NotEmpty<F: ConstrFnMut<'a>>;
+}
+
+impl<'a, N> ConstrFut<'a> for N
+where
+    N: AsyncNotifierTyped,
+{
+    type NotFull<F: ConstrFnMut<'a>> = <N as AsyncNotifierTyped>::FutNotFull<F, F::Out>;
+    type NotEmpty<F: ConstrFnMut<'a>> = <N as AsyncNotifierTyped>::FutNotEmpty<F, F::Out>;
+}

--- a/src/traits/notifier/typed.rs
+++ b/src/traits/notifier/typed.rs
@@ -7,8 +7,8 @@ use crate::traits::{
 use core::{future::Future, ops::Deref};
 
 pub trait AsyncNotifierTyped: Notifier {
-    type FutNotEmpty<F, T>: Future<Output = T>;
-    type FutNotFull<F, T>: Future<Output = T>;
+    type FutNotEmpty<F: FnMut() -> Option<T>, T>: Future<Output = T>;
+    type FutNotFull<F: FnMut() -> Option<T>, T>: Future<Output = T>;
 
     fn wait_for_not_empty<T, F: FnMut() -> Option<T>>(&self, f: F) -> Self::FutNotEmpty<F, T>;
     fn wait_for_not_full<T, F: FnMut() -> Option<T>>(&self, f: F) -> Self::FutNotFull<F, T>;


### PR DESCRIPTION
For a project I'm working on I needed a custom notifier with the specialty that the awoken futures also need to control how and when they get polled again, which means they need to have some way to get a handle to the notifier.

The obvious way to do give them that access was over the future that it returns. The only problem with that was that because of the async traits, all I get are opaque `impl Future<Output = T>` types.

My solution to that was to add an Interface that has you *manually* declare the concrete future types. See [`src/traits/notifier/typed.rs`](https://github.com/jamesmunns/bbq2/compare/main...titaniumtraveler:pr/typed-notifier-future?expand=1#diff-c01a77ec3bdfda5d84fa8d75fb666827426d181e36670a35a8e2f9bcb4cf00ad) specifically the [`AsyncNotifierTyped`](https://github.com/jamesmunns/bbq2/compare/main...titaniumtraveler:pr/typed-notifier-future?expand=1#diff-c01a77ec3bdfda5d84fa8d75fb666827426d181e36670a35a8e2f9bcb4cf00adR4-R10) trait.

That is then used to "override" the methods async methods (with a mean little `Deref` trick) to return the concrete notifier futures.

---

I'm not sure if this code is useful for you, but I would have felt weird not to at least offer it.