### PR TITLE
Lots of docs, API cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build and Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  miri:
+    name: "Build all crates"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install embedded target
+        # Note: once https://github.com/hawkw/mycelium/pull/538 lands we can test on
+        # thumbv6m-none-eabi
+        run: rustup target add thumbv7em-none-eabi
+      #
+      # BUILD + TEST
+      #
+      # no features, on std
+      - name: Check bbq2 (no features, on host)
+        run: cargo build --no-default-features
+      # default features, on std
+      - name: Check bbq2 (default features, on host)
+        run: cargo build
+      # std features, on std
+      - name: Check bbq2 (std features, on host)
+        run: cargo build --features=std
+      # std features, on std, test
+      - name: Test bbq2 (std features, on host)
+        run: cargo test --features=std
+
+      # no features, on mcu
+      - name: Check bbq2 (no features, on mcu)
+        run: cargo build --no-default-features --target=thumbv7em-none-eabi
+      # default features, on mcu
+      - name: Check bbq2 (no features, on mcu)
+        run: cargo build --target=thumbv7em-none-eabi
+

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,22 @@
+name: Run miri tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  miri:
+    name: "miri all the things"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install miri component
+        run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
+      #
+      # crate
+      #
+      - name: Miri test bbq2
+        run: ./miri.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
 name = "bbq2"
 version = "0.2.0"
 dependencies = [
+ "const-init",
  "critical-section",
  "maitake-sync",
  "tokio",
@@ -61,6 +62,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "const-init"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd422bfb4f24a97243f60b6a4443e63d810c925d8da4bb2d8fde26a7c1d57ec"
 
 [[package]]
 name = "cordyceps"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = [
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+const-init = "1.0.0"
 
 [dependencies.maitake-sync]
 version = "0.2"
@@ -33,19 +34,18 @@ features = ["macros", "rt", "time"]
 [features]
 default = [
     "cas-atomics",
-    "std",
     "maitake-sync-0_2",
     "critical-section",
-    # "tokio-sync",
 ]
+
 cas-atomics = []
 critical-section = [
     "dep:critical-section",
 ]
+disable-cache-padding = [
+    "maitake-sync?/no-cache-pad",
+]
 std = []
-# tokio-sync = [
-#     "dep:tokio",
-# ]
 maitake-sync-0_2 = [
     "dep:maitake-sync",
 ]

--- a/miri.sh
+++ b/miri.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# We disable isolation because we use tokio sleep
+# We disable leaks because ???
+#
+# TODO: Can we eliminate some of these limitations for testing?
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks" \
+    cargo +nightly miri test \
+    --target x86_64-unknown-linux-gnu \
+    --features=std

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,22 +5,28 @@
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 /// Type aliases for different generic configurations
+///
 pub mod nicknames;
 
 /// Producer and consumer interfaces
+///
 pub mod prod_cons;
 
 /// Queue storage
+///
 pub mod queue;
 
 /// Generic traits
+///
 pub mod traits;
 
+/// Re-export of external types/traits
+///
 pub mod export {
     pub use const_init::ConstInit;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use core::{ops::Deref, time::Duration};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,24 @@
-#![allow(clippy::result_unit_err)]
+//! bbq2
+//!
+//! A new and improved bipbuffer queue.
+
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
+/// Type aliases for different generic configurations
 pub mod nicknames;
+
+/// Producer and consumer interfaces
 pub mod prod_cons;
+
+/// Queue storage
 pub mod queue;
+
+/// Generic traits
 pub mod traits;
+
+pub mod export {
+    pub use const_init::ConstInit;
+}
 
 #[cfg(test)]
 mod test {
@@ -212,5 +226,7 @@ mod test {
         // todo: timeouts
         rxfut.await.unwrap();
         txfut.await.unwrap();
+
+        drop(bbq);
     }
 }

--- a/src/nicknames.rs
+++ b/src/nicknames.rs
@@ -19,6 +19,8 @@
 //! | Heap    | Atomic           | Async    | No     | Tandoori     | India         |
 //! | Heap    | Atomic           | Async    | Yes    | Lechon       | Philippines   |
 
+#![allow(unused_imports)]
+
 #[cfg(feature = "std")]
 use crate::queue::ArcBBQueue;
 #[cfg(feature = "cas-atomics")]

--- a/src/prod_cons/framed.rs
+++ b/src/prod_cons/framed.rs
@@ -88,8 +88,8 @@ where
     Q: BbqHandle,
     H: LenHeader,
 {
-    bbq: Q::Target,
-    pd: PhantomData<H>,
+    pub(crate) bbq: Q::Target,
+    pub(crate) pd: PhantomData<H>,
 }
 
 impl<Q, H> FramedProducer<Q, H>
@@ -131,8 +131,8 @@ where
     Q: BbqHandle,
     H: LenHeader,
 {
-    bbq: Q::Target,
-    pd: PhantomData<H>,
+    pub(crate) bbq: Q::Target,
+    pub(crate) pd: PhantomData<H>,
 }
 
 impl<Q, H> FramedConsumer<Q, H>

--- a/src/prod_cons/framed.rs
+++ b/src/prod_cons/framed.rs
@@ -1,27 +1,95 @@
+//! Framed byte queue interfaces
+//!
+//! Useful for sending data that has coherent frames, e.g. network packets
+
 use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
 
-use crate::{
-    queue::BBQueue,
-    traits::{
-        bbqhdl::BbqHandle,
-        coordination::{Coord, ReadGrantError, WriteGrantError},
-        notifier::{AsyncNotifier, Notifier},
-        storage::Storage,
-    },
+use crate::traits::{
+    bbqhdl::BbqHandle,
+    coordination::{Coord, ReadGrantError, WriteGrantError},
+    notifier::{AsyncNotifier, Notifier},
+    storage::Storage,
 };
 
+/// A trait that can be used as the "header" for separating framed storage.
+///
+/// Framed interfaces use a `u16` by default, which only requires two bytes
+/// for the header, with the limitation that the largest grant allowed is
+/// 64KiB at a time. You can also use a `usize` allowing the maximum platform
+/// available size.
+///
+/// You should not have to implement this trait.
+///
 /// # Safety
 ///
 /// Do it right
 pub unsafe trait LenHeader: Into<usize> + Copy + Ord {
+    /// Should be `[u8; size_of::<Self>()]`
     type Bytes;
+    /// Convert Self into Self::Bytes, in little endian order
     fn to_le_bytes(&self) -> Self::Bytes;
+    /// Convert Self::Bytes (which is in little endian order) to Self.
     fn from_le_bytes(by: Self::Bytes) -> Self;
 }
+
+/// A producer handle that can be used to write framed chunks
+pub struct FramedProducer<Q, H = u16>
+where
+    Q: BbqHandle,
+    H: LenHeader,
+{
+    pub(crate) bbq: Q::Target,
+    pub(crate) pd: PhantomData<H>,
+}
+
+/// A consumer handle that can be used to read framed chunks
+pub struct FramedConsumer<Q, H = u16>
+where
+    Q: BbqHandle,
+    H: LenHeader,
+{
+    pub(crate) bbq: Q::Target,
+    pub(crate) pd: PhantomData<H>,
+}
+
+/// A writing grant into the storage buffer
+///
+/// Grants implement Deref/DerefMut to access the contained storage.
+#[must_use = "Write Grants must be committed to be effective"]
+pub struct FramedGrantW<Q, H = u16>
+where
+    Q: BbqHandle,
+    H: LenHeader,
+{
+    bbq: Q::Target,
+    base_ptr: NonNull<u8>,
+    hdr: H,
+}
+
+/// A reading grant into the storage buffer
+///
+/// Grants implement Deref/DerefMut to access the contained storage.
+///
+/// Write access is provided for read grants in case it is necessary to mutate
+/// the storage in-place for decoding.
+#[must_use = "Read Grants must be released to free space"]
+pub struct FramedGrantR<Q, H = u16>
+where
+    Q: BbqHandle,
+    H: LenHeader,
+{
+    bbq: Q::Target,
+    body_ptr: NonNull<u8>,
+    hdr: H,
+}
+
+// ---- impls ----
+
+// ---- impl LenHeader ----
 
 unsafe impl LenHeader for u16 {
     type Bytes = [u8; 2];
@@ -36,6 +104,7 @@ unsafe impl LenHeader for u16 {
         u16::from_le_bytes(by)
     }
 }
+
 unsafe impl LenHeader for usize {
     type Bytes = [u8; core::mem::size_of::<usize>()];
 
@@ -50,53 +119,18 @@ unsafe impl LenHeader for usize {
     }
 }
 
-impl<S: Storage, C: Coord, N: Notifier> BBQueue<S, C, N> {
-    pub fn framed_producer(&self) -> FramedProducer<&'_ Self> {
-        FramedProducer {
-            bbq: self.bbq_ref(),
-            pd: PhantomData,
-        }
-    }
-
-    pub fn framed_consumer(&self) -> FramedConsumer<&'_ Self> {
-        FramedConsumer {
-            bbq: self.bbq_ref(),
-            pd: PhantomData,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
-    pub fn framed_producer(&self) -> FramedProducer<std::sync::Arc<BBQueue<S, C, N>>> {
-        FramedProducer {
-            bbq: self.0.bbq_ref(),
-            pd: PhantomData,
-        }
-    }
-
-    pub fn framed_consumer(&self) -> FramedConsumer<std::sync::Arc<BBQueue<S, C, N>>> {
-        FramedConsumer {
-            bbq: self.0.bbq_ref(),
-            pd: PhantomData,
-        }
-    }
-}
-
-pub struct FramedProducer<Q, H = u16>
-where
-    Q: BbqHandle,
-    H: LenHeader,
-{
-    pub(crate) bbq: Q::Target,
-    pub(crate) pd: PhantomData<H>,
-}
+// ---- impl FramedProducer ----
 
 impl<Q, H> FramedProducer<Q, H>
 where
     Q: BbqHandle,
     H: LenHeader,
 {
+    /// Attempt to obtain a write grant of the given (max) size
+    ///
+    /// The returned grant can be used to write up to `sz` bytes, though
+    /// a smaller size may be committed. Dropping the grant without calling
+    /// commit means that no data will be made visible to the consumer.
     pub fn grant(&self, sz: H) -> Result<FramedGrantW<Q, H>, WriteGrantError> {
         let (ptr, cap) = self.bbq.sto.ptr_len();
         let needed = sz.into() + core::mem::size_of::<H>();
@@ -121,25 +155,32 @@ where
     Q::Notifier: AsyncNotifier,
     H: LenHeader,
 {
+    /// Wait for the given write grant to become available
+    ///
+    /// If `sz` is larger than the storage buffer, this method will never
+    /// return.
+    ///
+    /// The returned grant can be used to write up to `sz` bytes, though
+    /// a smaller size may be committed. Dropping the grant without calling
+    /// commit means that no data will be made visible to the consumer.
     pub async fn wait_grant(&self, sz: H) -> FramedGrantW<Q, H> {
         self.bbq.not.wait_for_not_full(|| self.grant(sz).ok()).await
     }
 }
 
-pub struct FramedConsumer<Q, H = u16>
-where
-    Q: BbqHandle,
-    H: LenHeader,
-{
-    pub(crate) bbq: Q::Target,
-    pub(crate) pd: PhantomData<H>,
-}
+// ---- impl FramedConsumer ----
 
 impl<Q, H> FramedConsumer<Q, H>
 where
     Q: BbqHandle,
     H: LenHeader,
 {
+    /// Attempt to receive a single frame
+    ///
+    /// The FramedConsumer has no control over the size of the read grant,
+    /// we see whatever size was written by the FramedProducer.
+    ///
+    /// The returned grant must be released to free the space in the buffer.
     pub fn read(&self) -> Result<FramedGrantR<Q, H>, ReadGrantError> {
         let (ptr, _cap) = self.bbq.sto.ptr_len();
         let (offset, grant_len) = self.bbq.cor.read()?;
@@ -194,23 +235,43 @@ where
     }
 }
 
-pub struct FramedGrantW<Q, H = u16>
+// ---- impl FramedGrantW ----
+
+impl<Q, H> FramedGrantW<Q, H>
 where
     Q: BbqHandle,
     H: LenHeader,
 {
-    bbq: Q::Target,
-    base_ptr: NonNull<u8>,
-    hdr: H,
-}
+    /// Commit `used` bytes of the grant to be visible.
+    ///
+    /// If `used` is greater than the `sz` used to create this grant, the
+    /// amount will be clamped to `sz`.
+    pub fn commit(self, used: H) {
+        let (_ptr, cap) = self.bbq.sto.ptr_len();
+        let hdrlen: usize = const { core::mem::size_of::<H>() };
+        let grant_len = hdrlen + self.hdr.into();
+        let clamp_hdr = self.hdr.min(used);
+        let used_len: usize = hdrlen + clamp_hdr.into();
 
-unsafe impl<Q, H> Send for FramedGrantW<Q, H>
-where
-    Q: BbqHandle,
-    Q::Target: Send,
-    H: LenHeader + Send
-{
+        unsafe {
+            self.base_ptr
+                .cast::<H>()
+                .as_ptr()
+                .write_unaligned(clamp_hdr);
+        }
 
+        self.bbq.cor.commit_inner(cap, grant_len, used_len);
+        self.bbq.not.wake_one_consumer();
+        core::mem::forget(self);
+    }
+
+    /// Aborts the grant, making no frame available to the consumer
+    ///
+    /// Can be used to silence "must_use" errors.
+    pub fn abort(self) {
+        // The default behavior is to abort - do nothing, let the
+        // drop impl run
+    }
 }
 
 impl<Q, H> Deref for FramedGrantW<Q, H>
@@ -259,53 +320,39 @@ where
     }
 }
 
-impl<Q, H> FramedGrantW<Q, H>
-where
-    Q: BbqHandle,
-    H: LenHeader,
-{
-    pub fn commit(self, used: H) {
-        let (_ptr, cap) = self.bbq.sto.ptr_len();
-        let hdrlen: usize = const { core::mem::size_of::<H>() };
-        let grant_len = hdrlen + self.hdr.into();
-        let clamp_hdr = self.hdr.min(used);
-        let used_len: usize = hdrlen + clamp_hdr.into();
-
-        unsafe {
-            self.base_ptr
-                .cast::<H>()
-                .as_ptr()
-                .write_unaligned(clamp_hdr);
-        }
-
-        self.bbq.cor.commit_inner(cap, grant_len, used_len);
-        self.bbq.not.wake_one_consumer();
-        core::mem::forget(self);
-    }
-
-    pub fn abort(self) {
-        // The default behavior is to abort - do nothing, let the
-        // drop impl run
-    }
-}
-
-pub struct FramedGrantR<Q, H = u16>
-where
-    Q: BbqHandle,
-    H: LenHeader,
-{
-    bbq: Q::Target,
-    body_ptr: NonNull<u8>,
-    hdr: H,
-}
-
-unsafe impl<Q, H> Send for FramedGrantR<Q, H>
+unsafe impl<Q, H> Send for FramedGrantW<Q, H>
 where
     Q: BbqHandle,
     Q::Target: Send,
-    H: LenHeader + Send
+    H: LenHeader + Send,
 {
+}
 
+// ---- impl FramedGrantR ----
+
+impl<Q, H> FramedGrantR<Q, H>
+where
+    Q: BbqHandle,
+    H: LenHeader,
+{
+    /// Release the entire read grant
+    ///
+    /// It is not possible to partially release a framed read grant.
+    pub fn release(self) {
+        let len: usize = self.hdr.into();
+        let hdrlen: usize = const { core::mem::size_of::<H>() };
+        let used = len + hdrlen;
+        self.bbq.cor.release_inner(used);
+        self.bbq.not.wake_one_producer();
+        core::mem::forget(self);
+    }
+
+    /// Drop the grant WITHOUT releasing the message from the queue.
+    ///
+    /// The next call to read will observe the same packet again.
+    pub fn keep(self) {
+        // Default behavior is "keep"
+    }
 }
 
 impl<Q, H> Deref for FramedGrantR<Q, H>
@@ -343,21 +390,10 @@ where
     }
 }
 
-impl<Q, H> FramedGrantR<Q, H>
+unsafe impl<Q, H> Send for FramedGrantR<Q, H>
 where
     Q: BbqHandle,
-    H: LenHeader,
+    Q::Target: Send,
+    H: LenHeader + Send,
 {
-    pub fn release(self) {
-        let len: usize = self.hdr.into();
-        let hdrlen: usize = const { core::mem::size_of::<H>() };
-        let used = len + hdrlen;
-        self.bbq.cor.release_inner(used);
-        self.bbq.not.wake_one_producer();
-        core::mem::forget(self);
-    }
-
-    pub fn keep(self) {
-        // Default behavior is "keep"
-    }
 }

--- a/src/prod_cons/mod.rs
+++ b/src/prod_cons/mod.rs
@@ -1,2 +1,20 @@
+//! Producer and Consumer interfaces
+//!
+//! BBQueues can be used with one of two kinds of producer/consumer pairs:
+//!
+//! * **Framed**, where the consumer sees the exact chunks that were inserted by the
+//!   producer. This uses a small length header to note the length of the inserted frame.
+//!   This means that if the producer writes a 10 byte grant, a 20 byte grant, then a 30
+//!   byte grant, the consumer will need to read three times to drain the queue, seeing the
+//!   10, 20, and 30 byte chunks in order. This is useful when you are working with data that
+//!   has logical "frames", for example for network packets.
+//! * **Stream**, where the consumer may potentially see multiple pushed chunks at once, with
+//!   no separation. This means that if the producer writes a 10 byte grant, a 20 byte grant,
+//!   then a 30 byte grant, the consumer could potentially see all 60 bytes in a single read
+//!   grant (if there is no wrap-around).
+//!
+//! You should NOT "mix and match" framed/stream consumers and producers. This will not cause
+//! memory safety/UB issues, but will not work properly.
+
 pub mod framed;
 pub mod stream;

--- a/src/prod_cons/stream.rs
+++ b/src/prod_cons/stream.rs
@@ -46,7 +46,7 @@ pub struct StreamProducer<Q>
 where
     Q: BbqHandle,
 {
-    bbq: Q::Target,
+    pub(crate) bbq: Q::Target,
 }
 
 impl<Q> StreamProducer<Q>
@@ -110,7 +110,7 @@ pub struct StreamConsumer<Q>
 where
     Q: BbqHandle,
 {
-    bbq: Q::Target,
+    pub(crate) bbq: Q::Target,
 }
 
 impl<Q> StreamConsumer<Q>

--- a/src/prod_cons/stream.rs
+++ b/src/prod_cons/stream.rs
@@ -1,47 +1,23 @@
+//! Stream byte queue interfaces
+//!
+//! Useful for sending stream-oriented data where the consumer doesn't care
+//! about how the data was pushed, e.g. a serial port stream where multiple
+//! writes from the software may be transferred out over DMA in a single
+//! transfer.
+
 use core::{
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
 
-use crate::{
-    queue::BBQueue,
-    traits::{
-        bbqhdl::BbqHandle,
-        coordination::{Coord, ReadGrantError, WriteGrantError},
-        notifier::{AsyncNotifier, Notifier},
-        storage::Storage,
-    },
+use crate::traits::{
+    bbqhdl::BbqHandle,
+    coordination::{Coord, ReadGrantError, WriteGrantError},
+    notifier::{AsyncNotifier, Notifier},
+    storage::Storage,
 };
 
-impl<S: Storage, C: Coord, N: Notifier> BBQueue<S, C, N> {
-    pub fn stream_producer(&self) -> StreamProducer<&'_ Self> {
-        StreamProducer {
-            bbq: self.bbq_ref(),
-        }
-    }
-
-    pub fn stream_consumer(&self) -> StreamConsumer<&'_ Self> {
-        StreamConsumer {
-            bbq: self.bbq_ref(),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
-    pub fn stream_producer(&self) -> StreamProducer<std::sync::Arc<BBQueue<S, C, N>>> {
-        StreamProducer {
-            bbq: self.0.bbq_ref(),
-        }
-    }
-
-    pub fn stream_consumer(&self) -> StreamConsumer<std::sync::Arc<BBQueue<S, C, N>>> {
-        StreamConsumer {
-            bbq: self.0.bbq_ref(),
-        }
-    }
-}
-
+/// A producer handle that may write data into the buffer
 pub struct StreamProducer<Q>
 where
     Q: BbqHandle,
@@ -49,10 +25,67 @@ where
     pub(crate) bbq: Q::Target,
 }
 
+/// A consumer handle that may read data from the buffer
+pub struct StreamConsumer<Q>
+where
+    Q: BbqHandle,
+{
+    pub(crate) bbq: Q::Target,
+}
+
+/// A writing grant into the storage buffer
+///
+/// Grants implement Deref/DerefMut to access the contained storage.
+#[must_use = "Write Grants must be committed to be effective"]
+pub struct StreamGrantW<Q>
+where
+    Q: BbqHandle,
+{
+    bbq: Q::Target,
+    ptr: NonNull<u8>,
+    len: usize,
+    to_commit: usize,
+}
+
+/// A reading grant into the storage buffer
+///
+/// Grants implement Deref/DerefMut to access the contained storage.
+///
+/// Write access is provided for read grants in case it is necessary to mutate
+/// the storage in-place for decoding.
+pub struct StreamGrantR<Q>
+where
+    Q: BbqHandle,
+{
+    bbq: Q::Target,
+    ptr: NonNull<u8>,
+    len: usize,
+    to_release: usize,
+}
+
+// ---- impls ----
+
+// ---- StreamProducer ----
+
 impl<Q> StreamProducer<Q>
 where
     Q: BbqHandle,
 {
+    /// Obtain a grant UP TO the given `max` size.
+    ///
+    /// If we return a grant, it will have a nonzero amount of space.
+    ///
+    /// If the grant represents LESS than `max` size, this is due to either:
+    ///
+    /// * There is less than `max` free space available in the queue for writing
+    /// * The grant represents the remaining space in the buffer that WOULDN'T cause
+    ///   a wrap-around of the ring buffer
+    ///
+    /// This method will never cause an "early wraparound" of the ring buffer unless
+    /// there is no capacity without wrapping around. There may still be available
+    /// writing capacity in the buffer after commiting this write grant, so it may be
+    /// useful to call `grant_max_remaining` in a loop until `Err(WriteGrantError::InsufficientSize)`
+    /// is returned.
     pub fn grant_max_remaining(&self, max: usize) -> Result<StreamGrantW<Q>, WriteGrantError> {
         let (ptr, cap) = self.bbq.sto.ptr_len();
         let (offset, len) = self.bbq.cor.grant_max_remaining(cap, max)?;
@@ -68,6 +101,11 @@ where
         })
     }
 
+    /// Obtain a grant with EXACTLY `sz` capacity
+    ///
+    /// Unlike `grant_max_remaining`, if there is insufficient size at the "tail" of
+    /// the ring buffer, this method WILL cause a wrap-around to occur to attempt to
+    /// find the requested write capacity.
     pub fn grant_exact(&self, sz: usize) -> Result<StreamGrantW<Q>, WriteGrantError> {
         let (ptr, cap) = self.bbq.sto.ptr_len();
         let offset = self.bbq.cor.grant_exact(cap, sz)?;
@@ -89,6 +127,7 @@ where
     Q: BbqHandle,
     Q::Notifier: AsyncNotifier,
 {
+    /// Wait for a grant of any size, up to `max`, to become available
     pub async fn wait_grant_max_remaining(&self, max: usize) -> StreamGrantW<Q> {
         self.bbq
             .not
@@ -96,6 +135,9 @@ where
             .await
     }
 
+    /// Wait for a grant of EXACTLY `sz` to become available.
+    ///
+    /// If `sz` exceeds the capacity of the buffer, this method will never return.
     pub async fn wait_grant_exact(&self, sz: usize) -> StreamGrantW<Q> {
         self.bbq
             .not
@@ -106,17 +148,18 @@ where
 
 unsafe impl<Q: BbqHandle + Send> Send for StreamProducer<Q> {}
 
-pub struct StreamConsumer<Q>
-where
-    Q: BbqHandle,
-{
-    pub(crate) bbq: Q::Target,
-}
+// ---- StreamConsumer ----
 
 impl<Q> StreamConsumer<Q>
 where
     Q: BbqHandle,
 {
+    /// Obtain a chunk of readable data
+    ///
+    /// The returned chunk may NOT represent all available data if the available
+    /// data wraps around the internal ring buffer. You may want to call `read`
+    /// in a loop until `Err(ReadGrantError::Empty)` is returned if you want to
+    /// drain the queue entirely.
     pub fn read(&self) -> Result<StreamGrantR<Q>, ReadGrantError> {
         let (ptr, _cap) = self.bbq.sto.ptr_len();
         let (offset, len) = self.bbq.cor.read()?;
@@ -138,6 +181,7 @@ where
     Q: BbqHandle,
     Q::Notifier: AsyncNotifier,
 {
+    /// Wait for any read data to become available
     pub async fn wait_read(&self) -> StreamGrantR<Q> {
         self.bbq.not.wait_for_not_empty(|| self.read().ok()).await
     }
@@ -145,14 +189,21 @@ where
 
 unsafe impl<Q: BbqHandle + Send> Send for StreamConsumer<Q> {}
 
-pub struct StreamGrantW<Q>
+// ---- StreamGrantW ----
+
+impl<Q> StreamGrantW<Q>
 where
     Q: BbqHandle,
 {
-    bbq: Q::Target,
-    ptr: NonNull<u8>,
-    len: usize,
-    to_commit: usize,
+    pub fn commit(self, used: usize) {
+        let (_, cap) = self.bbq.sto.ptr_len();
+        let used = used.min(self.len);
+        self.bbq.cor.commit_inner(cap, self.len, used);
+        if used != 0 {
+            self.bbq.not.wake_one_consumer();
+        }
+        core::mem::forget(self);
+    }
 }
 
 impl<Q> Deref for StreamGrantW<Q>
@@ -175,8 +226,6 @@ where
     }
 }
 
-unsafe impl<Q: BbqHandle + Send> Send for StreamGrantW<Q> {}
-
 impl<Q> Drop for StreamGrantW<Q>
 where
     Q: BbqHandle,
@@ -198,29 +247,22 @@ where
     }
 }
 
-impl<Q> StreamGrantW<Q>
+unsafe impl<Q: BbqHandle + Send> Send for StreamGrantW<Q> {}
+
+// ---- StreamGrantR ----
+
+impl<Q> StreamGrantR<Q>
 where
     Q: BbqHandle,
 {
-    pub fn commit(self, used: usize) {
-        let (_, cap) = self.bbq.sto.ptr_len();
+    pub fn release(self, used: usize) {
         let used = used.min(self.len);
-        self.bbq.cor.commit_inner(cap, self.len, used);
+        self.bbq.cor.release_inner(used);
         if used != 0 {
-            self.bbq.not.wake_one_consumer();
+            self.bbq.not.wake_one_producer();
         }
         core::mem::forget(self);
     }
-}
-
-pub struct StreamGrantR<Q>
-where
-    Q: BbqHandle,
-{
-    bbq: Q::Target,
-    ptr: NonNull<u8>,
-    len: usize,
-    to_release: usize,
 }
 
 impl<Q> Deref for StreamGrantR<Q>
@@ -243,8 +285,6 @@ where
     }
 }
 
-unsafe impl<Q: BbqHandle + Send> Send for StreamGrantR<Q> {}
-
 impl<Q> Drop for StreamGrantR<Q>
 where
     Q: BbqHandle,
@@ -265,16 +305,4 @@ where
     }
 }
 
-impl<Q> StreamGrantR<Q>
-where
-    Q: BbqHandle,
-{
-    pub fn release(self, used: usize) {
-        let used = used.min(self.len);
-        self.bbq.cor.release_inner(used);
-        if used != 0 {
-            self.bbq.not.wake_one_producer();
-        }
-        core::mem::forget(self);
-    }
-}
+unsafe impl<Q: BbqHandle + Send> Send for StreamGrantR<Q> {}

--- a/src/prod_cons/stream.rs
+++ b/src/prod_cons/stream.rs
@@ -7,7 +7,7 @@ use crate::{
     queue::BBQueue,
     traits::{
         bbqhdl::BbqHandle,
-        coordination::Coord,
+        coordination::{Coord, ReadGrantError, WriteGrantError},
         notifier::{AsyncNotifier, Notifier},
         storage::Storage,
     },
@@ -53,7 +53,7 @@ impl<Q> StreamProducer<Q>
 where
     Q: BbqHandle,
 {
-    pub fn grant_max_remaining(&self, max: usize) -> Result<StreamGrantW<Q>, ()> {
+    pub fn grant_max_remaining(&self, max: usize) -> Result<StreamGrantW<Q>, WriteGrantError> {
         let (ptr, cap) = self.bbq.sto.ptr_len();
         let (offset, len) = self.bbq.cor.grant_max_remaining(cap, max)?;
         let ptr = unsafe {
@@ -68,7 +68,7 @@ where
         })
     }
 
-    pub fn grant_exact(&self, sz: usize) -> Result<StreamGrantW<Q>, ()> {
+    pub fn grant_exact(&self, sz: usize) -> Result<StreamGrantW<Q>, WriteGrantError> {
         let (ptr, cap) = self.bbq.sto.ptr_len();
         let offset = self.bbq.cor.grant_exact(cap, sz)?;
         let ptr = unsafe {
@@ -117,7 +117,7 @@ impl<Q> StreamConsumer<Q>
 where
     Q: BbqHandle,
 {
-    pub fn read(&self) -> Result<StreamGrantR<Q>, ()> {
+    pub fn read(&self) -> Result<StreamGrantR<Q>, ReadGrantError> {
         let (ptr, _cap) = self.bbq.sto.ptr_len();
         let (offset, len) = self.bbq.cor.read()?;
         let ptr = unsafe {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,9 +1,10 @@
-use crate::traits::{
-    coordination::Coord,
-    notifier::Notifier,
-    storage::{ConstStorage, Storage},
-};
+use core::marker::PhantomData;
 
+use crate::{prod_cons::{framed::{FramedConsumer, FramedProducer}, stream::{StreamConsumer, StreamProducer}}, traits::{
+    bbqhdl::BbqHandle, coordination::Coord, notifier::Notifier, storage::{ConstStorage, Storage}
+}};
+
+/// A standard bbqueue
 pub struct BBQueue<S, C, N> {
     pub(crate) sto: S,
     pub(crate) cor: C,
@@ -20,6 +21,7 @@ impl<S: Storage, C: Coord, N: Notifier> BBQueue<S, C, N> {
     }
 }
 
+/// A BBQueue wrapped in an Arc
 #[cfg(feature = "std")]
 pub struct ArcBBQueue<S, C, N>(pub(crate) std::sync::Arc<BBQueue<S, C, N>>);
 
@@ -37,6 +39,64 @@ impl<S: ConstStorage, C: Coord, N: Notifier> BBQueue<S, C, N> {
             sto: S::INIT,
             cor: C::INIT,
             not: N::INIT,
+        }
+    }
+}
+
+
+impl<S: Storage, C: Coord, N: Notifier> BBQueue<S, C, N> {
+    pub fn framed_producer(&self) -> FramedProducer<&'_ Self> {
+        FramedProducer {
+            bbq: self.bbq_ref(),
+            pd: PhantomData,
+        }
+    }
+
+    pub fn framed_consumer(&self) -> FramedConsumer<&'_ Self> {
+        FramedConsumer {
+            bbq: self.bbq_ref(),
+            pd: PhantomData,
+        }
+    }
+
+    pub fn stream_producer(&self) -> StreamProducer<&'_ Self> {
+        StreamProducer {
+            bbq: self.bbq_ref(),
+        }
+    }
+
+    pub fn stream_consumer(&self) -> StreamConsumer<&'_ Self> {
+        StreamConsumer {
+            bbq: self.bbq_ref(),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S: Storage, C: Coord, N: Notifier> crate::queue::ArcBBQueue<S, C, N> {
+    pub fn framed_producer(&self) -> FramedProducer<std::sync::Arc<BBQueue<S, C, N>>> {
+        FramedProducer {
+            bbq: self.0.bbq_ref(),
+            pd: PhantomData,
+        }
+    }
+
+    pub fn framed_consumer(&self) -> FramedConsumer<std::sync::Arc<BBQueue<S, C, N>>> {
+        FramedConsumer {
+            bbq: self.0.bbq_ref(),
+            pd: PhantomData,
+        }
+    }
+
+    pub fn stream_producer(&self) -> StreamProducer<std::sync::Arc<BBQueue<S, C, N>>> {
+        StreamProducer {
+            bbq: self.0.bbq_ref(),
+        }
+    }
+
+    pub fn stream_consumer(&self) -> StreamConsumer<std::sync::Arc<BBQueue<S, C, N>>> {
+        StreamConsumer {
+            bbq: self.0.bbq_ref(),
         }
     }
 }

--- a/src/traits/bbqhdl.rs
+++ b/src/traits/bbqhdl.rs
@@ -1,14 +1,38 @@
+//! "Access" functionality
+//!
+//! This trait allows us to be generic over things like whether the
+//! BBQueue is stored as a static (and we use a `&'static` reference
+//! to it), or if the BBQueue is stored in an `Arc`, and we clone the
+//! Arc when creating producers and consumers.
+//!
+//! While `storage` is where/how the *data* is stored, `bbqhdl` is where
+//! the shared *header* is stored.
+//!
+//! The `BbqHandle` trait also serves to "bundle" all the other generics
+//! into a single trait with associated types, meaning MOST of the time
+//! you code only needs to be generic over `Q: BbqHandle`, and not all four
+//! generic types. You can still set trait bounds in where clauses for things
+//! like "has async notifications" by using additional `where`-clause like
+//! `where Q::BbqHandle, Q::Coord: AsyncCoord`.
+
 use core::{marker::PhantomData, ops::Deref};
 
 use crate::{prod_cons::{framed::{FramedConsumer, FramedProducer, LenHeader}, stream::{StreamConsumer, StreamProducer}}, queue::BBQueue};
 
 use super::{coordination::Coord, notifier::Notifier, storage::Storage};
 
+/// The "Access" trait
 pub trait BbqHandle: Sized {
+    /// How we reference our BBQueue.
     type Target: Deref<Target = BBQueue<Self::Storage, Self::Coord, Self::Notifier>> + Clone;
+    /// How the DATA of our BBQueue is stored
     type Storage: Storage;
+    /// How the producers/consumers of this BBQueue coordinate
     type Coord: Coord;
+    /// How we notify the producer/consumers of this BBQueue
     type Notifier: Notifier;
+
+    // Obtain a reference to
     fn bbq_ref(&self) -> Self::Target;
 
     fn stream_producer(&self) -> StreamProducer<Self> {

--- a/src/traits/bbqhdl.rs
+++ b/src/traits/bbqhdl.rs
@@ -5,7 +5,7 @@ use crate::{prod_cons::{framed::{FramedConsumer, FramedProducer, LenHeader}, str
 use super::{coordination::Coord, notifier::Notifier, storage::Storage};
 
 pub trait BbqHandle: Sized {
-    type Target: Deref<Target = BBQueue<Self::Storage, Self::Coord, Self::Notifier>> + Clone + Sized;
+    type Target: Deref<Target = BBQueue<Self::Storage, Self::Coord, Self::Notifier>> + Clone;
     type Storage: Storage;
     type Coord: Coord;
     type Notifier: Notifier;

--- a/src/traits/bbqhdl.rs
+++ b/src/traits/bbqhdl.rs
@@ -1,15 +1,41 @@
-use core::ops::Deref;
+use core::{marker::PhantomData, ops::Deref};
 
-use crate::queue::BBQueue;
+use crate::{prod_cons::{framed::{FramedConsumer, FramedProducer, LenHeader}, stream::{StreamConsumer, StreamProducer}}, queue::BBQueue};
 
 use super::{coordination::Coord, notifier::Notifier, storage::Storage};
 
-pub trait BbqHandle {
-    type Target: Deref<Target = BBQueue<Self::Storage, Self::Coord, Self::Notifier>> + Clone;
+pub trait BbqHandle: Sized {
+    type Target: Deref<Target = BBQueue<Self::Storage, Self::Coord, Self::Notifier>> + Clone + Sized;
     type Storage: Storage;
     type Coord: Coord;
     type Notifier: Notifier;
     fn bbq_ref(&self) -> Self::Target;
+
+    fn stream_producer(&self) -> StreamProducer<Self> {
+        StreamProducer {
+            bbq: self.bbq_ref(),
+        }
+    }
+
+    fn stream_consumer(&self) -> StreamConsumer<Self> {
+        StreamConsumer {
+            bbq: self.bbq_ref(),
+        }
+    }
+
+    fn framed_producer<H: LenHeader>(&self) -> FramedProducer<Self, H> {
+        FramedProducer {
+            bbq: self.bbq_ref(),
+            pd: PhantomData,
+        }
+    }
+
+    fn framed_consumer<H: LenHeader>(&self) -> FramedConsumer<Self, H> {
+        FramedConsumer {
+            bbq: self.bbq_ref(),
+            pd: PhantomData,
+        }
+    }
 }
 
 impl<S: Storage, C: Coord, N: Notifier> BbqHandle for &'_ BBQueue<S, C, N> {

--- a/src/traits/coordination/cas.rs
+++ b/src/traits/coordination/cas.rs
@@ -1,4 +1,4 @@
-use super::Coord;
+use super::{Coord, ReadGrantError, WriteGrantError};
 use core::{
     cmp::min,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -62,10 +62,9 @@ unsafe impl Coord for AtomicCoord {
         self.last.store(0, Ordering::Release);
     }
 
-    fn grant_max_remaining(&self, capacity: usize, mut sz: usize) -> Result<(usize, usize), ()> {
+    fn grant_max_remaining(&self, capacity: usize, mut sz: usize) -> Result<(usize, usize), WriteGrantError> {
         if self.write_in_progress.swap(true, Ordering::AcqRel) {
-            // return Err(Error::GrantInProgress);
-            return Err(());
+            return Err(WriteGrantError::GrantInProgress);
         }
 
         // Writer component. Must never write to `read`,
@@ -86,8 +85,7 @@ unsafe impl Coord for AtomicCoord {
             } else {
                 // Inverted, no room is available
                 self.write_in_progress.store(false, Ordering::Release);
-                // return Err(Error::InsufficientSize);
-                return Err(());
+                return Err(WriteGrantError::InsufficientSize);
             }
         } else {
             #[allow(clippy::collapsible_if)]
@@ -107,8 +105,7 @@ unsafe impl Coord for AtomicCoord {
                 } else {
                     // Not invertible, no space
                     self.write_in_progress.store(false, Ordering::Release);
-                    // return Err(Error::InsufficientSize);
-                    return Err(());
+                    return Err(WriteGrantError::InsufficientSize);
                 }
             }
         };
@@ -119,10 +116,9 @@ unsafe impl Coord for AtomicCoord {
         Ok((start, sz))
     }
 
-    fn grant_exact(&self, capacity: usize, sz: usize) -> Result<usize, ()> {
+    fn grant_exact(&self, capacity: usize, sz: usize) -> Result<usize, WriteGrantError> {
         if self.write_in_progress.swap(true, Ordering::AcqRel) {
-            // return Err(Error::GrantInProgress);
-            return Err(());
+            return Err(WriteGrantError::GrantInProgress);
         }
 
         // Writer component. Must never write to `read`,
@@ -139,8 +135,7 @@ unsafe impl Coord for AtomicCoord {
             } else {
                 // Inverted, no room is available
                 self.write_in_progress.store(false, Ordering::Release);
-                // return Err(Error::InsufficientSize);
-                return Err(());
+                return Err(WriteGrantError::InsufficientSize);
             }
         } else {
             #[allow(clippy::collapsible_if)]
@@ -159,8 +154,7 @@ unsafe impl Coord for AtomicCoord {
                 } else {
                     // Not invertible, no space
                     self.write_in_progress.store(false, Ordering::Release);
-                    // return Err(Error::InsufficientSize);
-                    return Err(());
+                    return Err(WriteGrantError::InsufficientSize);
                 }
             }
         };
@@ -171,10 +165,9 @@ unsafe impl Coord for AtomicCoord {
         Ok(start)
     }
 
-    fn read(&self) -> Result<(usize, usize), ()> {
+    fn read(&self) -> Result<(usize, usize), ReadGrantError> {
         if self.read_in_progress.swap(true, Ordering::AcqRel) {
-            // return Err(Error::GrantInProgress);
-            return Err(());
+            return Err(ReadGrantError::GrantInProgress);
         }
 
         let write = self.write.load(Ordering::Acquire);
@@ -205,8 +198,7 @@ unsafe impl Coord for AtomicCoord {
 
         if sz == 0 {
             self.read_in_progress.store(false, Ordering::Release);
-            // return Err(Error::InsufficientSize);
-            return Err(());
+            return Err(ReadGrantError::Empty);
         }
 
         Ok((read, sz))

--- a/src/traits/coordination/cas.rs
+++ b/src/traits/coordination/cas.rs
@@ -1,9 +1,12 @@
+//! Lock-free coordination based on Compare and Swap atomics
+
 use super::{Coord, ReadGrantError, WriteGrantError};
 use core::{
     cmp::min,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
+/// Coordination using CAS atomics
 pub struct AtomicCoord {
     /// Where the next byte will be written
     write: AtomicUsize,

--- a/src/traits/coordination/cs.rs
+++ b/src/traits/coordination/cs.rs
@@ -1,9 +1,18 @@
+//! Mutex/Critical section based coordination
+//!
+//! This is provided so bbq2 is usable on bare metal targets that don't
+//! have CAS atomics, like `cortex-m0`/`thumbv6m` targets.
+
 use super::{Coord, ReadGrantError, WriteGrantError};
 use core::{
     cmp::min,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
+/// Coordination that uses a critical section to perform coordination operations
+///
+/// The critical section is only taken for a short time to obtain or release grants,
+/// not for the entire duration of the grant.
 pub struct CsCoord {
     /// Where the next byte will be written
     write: AtomicUsize,

--- a/src/traits/coordination/mod.rs
+++ b/src/traits/coordination/mod.rs
@@ -1,9 +1,18 @@
+//! "Coordination" functionality
+//!
+//! This trait is used to coordinate between Producers and Consumers.
+//!
+//! Unless you are on an embedded target without Compare and Swap atomics, e.g.
+//! `cortex-m0`/`thumbv6m`, you almost certainly want to use the [`cas`] version
+//! of coordination.
+
 #[cfg(feature = "cas-atomics")]
 pub mod cas;
 
 #[cfg(feature = "critical-section")]
 pub mod cs;
 
+/// Errors associated with obtaining a write grant
 #[derive(PartialEq, Debug)]
 pub enum WriteGrantError {
     /// Unable to create write grant due to not enough room in the buffer
@@ -12,6 +21,7 @@ pub enum WriteGrantError {
     GrantInProgress,
 }
 
+/// Errors associated with obtaining a read grant
 #[derive(PartialEq, Debug)]
 pub enum ReadGrantError {
     /// Unable to create write grant due to not enough room in the buffer

--- a/src/traits/coordination/mod.rs
+++ b/src/traits/coordination/mod.rs
@@ -4,6 +4,29 @@ pub mod cas;
 #[cfg(feature = "critical-section")]
 pub mod cs;
 
+#[derive(PartialEq, Debug)]
+pub enum WriteGrantError {
+    /// Unable to create write grant due to not enough room in the buffer
+    InsufficientSize,
+    /// Unable to create write grant due to existing write grant
+    GrantInProgress,
+}
+
+#[derive(PartialEq, Debug)]
+pub enum ReadGrantError {
+    /// Unable to create write grant due to not enough room in the buffer
+    Empty,
+    /// Unable to create write grant due to existing write grant
+    GrantInProgress,
+    /// We observed a frame header that did not make sense. This should only
+    /// occur if a stream producer was used on one end and a frame consumer was
+    /// used on the other end. Don't do that.
+    ///
+    /// If you see this error and you are NOT doing that, please report it, as it
+    /// is a bug.
+    InconsistentFrameHeader,
+}
+
 /// Coordination Handler
 ///
 /// The coordination handler is responsible for arbitrating access to the storage
@@ -19,12 +42,12 @@ pub unsafe trait Coord {
 
     // Write Grants
 
-    fn grant_max_remaining(&self, capacity: usize, sz: usize) -> Result<(usize, usize), ()>;
-    fn grant_exact(&self, capacity: usize, sz: usize) -> Result<usize, ()>;
+    fn grant_max_remaining(&self, capacity: usize, sz: usize) -> Result<(usize, usize), WriteGrantError>;
+    fn grant_exact(&self, capacity: usize, sz: usize) -> Result<usize, WriteGrantError>;
     fn commit_inner(&self, capacity: usize, grant_len: usize, used: usize);
 
     // Read Grants
 
-    fn read(&self) -> Result<(usize, usize), ()>;
+    fn read(&self) -> Result<(usize, usize), ReadGrantError>;
     fn release_inner(&self, used: usize);
 }

--- a/src/traits/notifier/blocking.rs
+++ b/src/traits/notifier/blocking.rs
@@ -1,10 +1,14 @@
 use super::Notifier;
+use const_init::ConstInit;
 
 pub struct Blocking;
 
 // Blocking performs no notification
 impl Notifier for Blocking {
-    const INIT: Self = Blocking;
     fn wake_one_consumer(&self) {}
     fn wake_one_producer(&self) {}
+}
+
+impl ConstInit for Blocking {
+    const INIT: Self = Blocking;
 }

--- a/src/traits/notifier/maitake.rs
+++ b/src/traits/notifier/maitake.rs
@@ -1,4 +1,4 @@
-use maitake_sync::{WaitCell, WaitQueue};
+use maitake_sync::WaitCell;
 
 use super::{AsyncNotifier, Notifier};
 
@@ -36,51 +36,6 @@ impl Notifier for MaiNotSpsc {
 }
 
 impl AsyncNotifier for MaiNotSpsc {
-    async fn wait_for_not_empty<T, F: FnMut() -> Option<T>>(&self, f: F) -> T {
-        self.not_empty.wait_for_value(f).await.unwrap()
-    }
-
-    async fn wait_for_not_full<T, F: FnMut() -> Option<T>>(&self, f: F) -> T {
-        self.not_full.wait_for_value(f).await.unwrap()
-    }
-}
-
-// ---
-
-pub struct MaiNotMpsc {
-    not_empty: WaitCell,
-    not_full: WaitQueue,
-}
-
-impl MaiNotMpsc {
-    pub fn new() -> Self {
-        Self::INIT
-    }
-}
-
-impl Default for MaiNotMpsc {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Notifier for MaiNotMpsc {
-    #[allow(clippy::declare_interior_mutable_const)]
-    const INIT: Self = Self {
-        not_empty: WaitCell::new(),
-        not_full: WaitQueue::new(),
-    };
-
-    fn wake_one_consumer(&self) {
-        _ = self.not_empty.wake();
-    }
-
-    fn wake_one_producer(&self) {
-        self.not_full.wake();
-    }
-}
-
-impl AsyncNotifier for MaiNotMpsc {
     async fn wait_for_not_empty<T, F: FnMut() -> Option<T>>(&self, f: F) -> T {
         self.not_empty.wait_for_value(f).await.unwrap()
     }

--- a/src/traits/notifier/maitake.rs
+++ b/src/traits/notifier/maitake.rs
@@ -1,7 +1,12 @@
+use const_init::ConstInit;
 use maitake_sync::WaitCell;
 
 use super::{AsyncNotifier, Notifier};
 
+/// A Maitake-Sync based SPSC notifier
+///
+/// Usable for async context. Should not be used with multiple consumers or multiple producers
+/// at the same time.
 pub struct MaiNotSpsc {
     not_empty: WaitCell,
     not_full: WaitCell,
@@ -19,13 +24,15 @@ impl Default for MaiNotSpsc {
     }
 }
 
-impl Notifier for MaiNotSpsc {
+impl ConstInit for MaiNotSpsc {
     #[allow(clippy::declare_interior_mutable_const)]
     const INIT: Self = Self {
         not_empty: WaitCell::new(),
         not_full: WaitCell::new(),
     };
+}
 
+impl Notifier for MaiNotSpsc {
     fn wake_one_consumer(&self) {
         _ = self.not_empty.wake();
     }

--- a/src/traits/notifier/mod.rs
+++ b/src/traits/notifier/mod.rs
@@ -1,15 +1,21 @@
+//! "Notification" functionality
+//!
+//! This functionality allows (or doesn't allow) for awaiting a read/write grant
+
+use const_init::ConstInit;
+
 #[cfg(feature = "maitake-sync-0_2")]
 pub mod maitake;
 
 pub mod blocking;
 
-pub trait Notifier {
-    const INIT: Self;
-
+/// Non-async notifications
+pub trait Notifier: ConstInit {
     fn wake_one_consumer(&self);
     fn wake_one_producer(&self);
 }
 
+/// Async notifications
 #[allow(async_fn_in_trait)]
 pub trait AsyncNotifier: Notifier {
     async fn wait_for_not_empty<T, F: FnMut() -> Option<T>>(&self, f: F) -> T;

--- a/src/traits/storage.rs
+++ b/src/traits/storage.rs
@@ -1,14 +1,32 @@
+//! "Storage" functionality
+//!
+//! This trait defines how the "data" part of the ring buffer is stored.
+//!
+//! This is typically "inline", e.g. stored as an owned `[u8; N]` array,
+//! or heap allocated, e.g. as a `Box<[u8]>`.
+//!
+//! Inline storage is useful for static allocation, or cases where a fixed
+//! buffer is useful. Heap storage is useful when you need dynamically sized
+//! storage, e.g. of a size provided from CLI args or a configuration file
+//! at runtime.
+
 use const_init::ConstInit;
 use core::{cell::UnsafeCell, mem::MaybeUninit, ptr::NonNull};
 
+/// Trait for providing access to the storage
+///
+/// Must always return the same ptr/len forever.
 pub trait Storage {
     fn ptr_len(&self) -> (NonNull<u8>, usize);
 }
 
+/// A marker trait that the item is BOTH storage and can be initialized as a constant
+///
+/// This allows for making `static` versions of the bbqueue.
 pub trait ConstStorage: Storage + ConstInit {}
-
 impl<T> ConstStorage for T where T: Storage + ConstInit {}
 
+/// Inline/array-ful storage
 #[repr(transparent)]
 pub struct Inline<const N: usize> {
     buf: UnsafeCell<MaybeUninit<[u8; N]>>,
@@ -61,6 +79,7 @@ impl<const N: usize> Storage for &'_ Inline<N> {
     }
 }
 
+/// Boxed/heap-ful storage
 #[cfg(feature = "std")]
 pub struct BoxedSlice {
     buf: Box<[UnsafeCell<MaybeUninit<u8>>]>,
@@ -71,6 +90,7 @@ unsafe impl Sync for BoxedSlice {}
 
 #[cfg(feature = "std")]
 impl BoxedSlice {
+    /// Create a new BoxedSlice with capacity `len`.
     pub fn new(len: usize) -> Self {
         let buf: Box<[UnsafeCell<MaybeUninit<u8>>]> = {
             let mut v: Vec<UnsafeCell<MaybeUninit<u8>>> = Vec::with_capacity(len);

--- a/src/traits/storage.rs
+++ b/src/traits/storage.rs
@@ -1,12 +1,13 @@
+use const_init::ConstInit;
 use core::{cell::UnsafeCell, mem::MaybeUninit, ptr::NonNull};
 
 pub trait Storage {
     fn ptr_len(&self) -> (NonNull<u8>, usize);
 }
 
-pub trait ConstStorage: Storage {
-    const INIT: Self;
-}
+pub trait ConstStorage: Storage + ConstInit {}
+
+impl<T> ConstStorage for T where T: Storage + ConstInit {}
 
 #[repr(transparent)]
 pub struct Inline<const N: usize> {
@@ -43,11 +44,12 @@ impl<const N: usize> Storage for Inline<N> {
     }
 }
 
-impl<const N: usize> ConstStorage for Inline<N> {
+#[allow(clippy::declare_interior_mutable_const)]
+impl<const N: usize> ConstInit for Inline<N> {
     const INIT: Self = Self::new();
 }
 
-impl<'a, const N: usize> Storage for &'a Inline<N> {
+impl<const N: usize> Storage for &'_ Inline<N> {
     fn ptr_len(&self) -> (NonNull<u8>, usize) {
         let len = N;
 


### PR DESCRIPTION
This adds:

* Accessor functions on the handle to get producer/consumers, which is useful for preserving the `BbqHandle` generic when you're holding a handle
* Adds a ton of docs
* Adds real error types for grants
* Adds CI

This is going to be the 0.3 release very shortly.