### PR TITLE
Remove `cas-atomics` feature, automatically detect CAS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "bbq2"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "const-init",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bbq2"
-version = "0.3.0"
+version = "0.4.0"
 description = "A SPSC, lockless, no_std, thread safe, queue, based on BipBuffers"
 repository = "https://github.com/jamesmunns/bbq2"
 authors = ["James Munns <james@onevariable.com>"]
@@ -38,13 +38,11 @@ version = "1.0"
 features = ["macros", "rt", "time"]
 
 [features]
+# NOTE: CAS atomics are switched using `#[cfg(target_has_atomic = "ptr")]`
 default = [
     "maitake-sync-0_2",
     "critical-section",
 ]
-
-# TODO: Remove this, switched to using `#[cfg(target_has_atomic = "ptr")]`
-cas-atomics = []
 critical-section = [
     "dep:critical-section",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ features = ["macros", "rt", "time"]
 
 [features]
 default = [
-    "cas-atomics",
     "maitake-sync-0_2",
     "critical-section",
 ]
 
+# TODO: Remove this, switched to using `#[cfg(target_has_atomic = "ptr")]`
 cas-atomics = []
 critical-section = [
     "dep:critical-section",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod test {
         },
     };
 
-    #[cfg(all(feature = "cas-atomics", feature = "std"))]
+    #[cfg(all(target_has_atomic = "ptr", feature = "std"))]
     #[test]
     fn ux() {
         use crate::traits::{notifier::blocking::Blocking, storage::BoxedSlice};
@@ -59,7 +59,7 @@ mod test {
         let _ = bbq3.stream_consumer();
     }
 
-    #[cfg(feature = "cas-atomics")]
+    #[cfg(target_has_atomic = "ptr")]
     #[test]
     fn smoke() {
         use crate::traits::notifier::blocking::Blocking;
@@ -85,7 +85,7 @@ mod test {
         assert!(cons.read().is_err());
     }
 
-    #[cfg(feature = "cas-atomics")]
+    #[cfg(target_has_atomic = "ptr")]
     #[test]
     fn smoke_framed() {
         use crate::traits::notifier::blocking::Blocking;
@@ -107,7 +107,7 @@ mod test {
         assert!(cons.read().is_err());
     }
 
-    #[cfg(feature = "cas-atomics")]
+    #[cfg(target_has_atomic = "ptr")]
     #[test]
     fn framed_misuse() {
         use crate::traits::notifier::blocking::Blocking;

--- a/src/nicknames.rs
+++ b/src/nicknames.rs
@@ -23,7 +23,7 @@
 
 #[cfg(feature = "std")]
 use crate::queue::ArcBBQueue;
-#[cfg(feature = "cas-atomics")]
+#[cfg(target_has_atomic = "ptr")]
 use crate::traits::coordination::cas::AtomicCoord;
 #[cfg(feature = "critical-section")]
 use crate::traits::coordination::cs::CsCoord;
@@ -43,11 +43,11 @@ pub type Jerk<const N: usize> = BBQueue<Inline<N>, CsCoord, Blocking>;
 pub type Memphis<const N: usize, A> = BBQueue<Inline<N>, CsCoord, A>;
 
 /// Inline Storage, Atomics, Blocking, Borrowed
-#[cfg(feature = "cas-atomics")]
+#[cfg(target_has_atomic = "ptr")]
 pub type Churrasco<const N: usize> = BBQueue<Inline<N>, AtomicCoord, Blocking>;
 
 /// Inline Storage, Atomics, Async, Borrowed
-#[cfg(feature = "cas-atomics")]
+#[cfg(target_has_atomic = "ptr")]
 pub type Texas<const N: usize, A> = BBQueue<Inline<N>, AtomicCoord, A>;
 
 /// Heap Buffer, Critical Section, Blocking, Borrowed
@@ -59,11 +59,11 @@ pub type Braai = BBQueue<BoxedSlice, CsCoord, Blocking>;
 pub type SiuMei<A> = BBQueue<BoxedSlice, CsCoord, A>;
 
 /// Heap Buffer, Atomics, Blocking, Borrowed
-#[cfg(all(feature = "std", feature = "cas-atomics"))]
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
 pub type YakiNiku = BBQueue<BoxedSlice, AtomicCoord, Blocking>;
 
 /// Heap Buffer, Atomics, Async, Borrowed
-#[cfg(all(feature = "std", feature = "cas-atomics"))]
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
 pub type Tandoori<A> = BBQueue<BoxedSlice, AtomicCoord, A>;
 
 /// Inline Storage, Critical Section, Blocking, Arc
@@ -75,11 +75,11 @@ pub type Asado<const N: usize> = ArcBBQueue<Inline<N>, CsCoord, Blocking>;
 pub type Carolina<const N: usize, A> = ArcBBQueue<Inline<N>, CsCoord, A>;
 
 /// Inline Storage, Atomics, Blocking, Arc
-#[cfg(all(feature = "std", feature = "cas-atomics"))]
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
 pub type Barbacoa<const N: usize> = ArcBBQueue<Inline<N>, AtomicCoord, Blocking>;
 
 /// Inline Storage, Atomics, Async, Arc
-#[cfg(all(feature = "std", feature = "cas-atomics"))]
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
 pub type KansasCity<const N: usize, A> = ArcBBQueue<Inline<N>, AtomicCoord, A>;
 
 /// Heap Buffer, Critical Section, Blocking, Arc
@@ -91,9 +91,9 @@ pub type Kebab = ArcBBQueue<BoxedSlice, CsCoord, Blocking>;
 pub type Satay<A> = ArcBBQueue<BoxedSlice, CsCoord, A>;
 
 /// Heap Buffer, Atomics, Blocking, Arc
-#[cfg(all(feature = "std", feature = "cas-atomics"))]
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
 pub type GogiGui = ArcBBQueue<BoxedSlice, AtomicCoord, Blocking>;
 
 /// Heap Buffer, Atomics, Async, Arc
-#[cfg(all(feature = "std", feature = "cas-atomics"))]
+#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
 pub type Lechon<A> = ArcBBQueue<BoxedSlice, AtomicCoord, A>;

--- a/src/traits/coordination/mod.rs
+++ b/src/traits/coordination/mod.rs
@@ -6,7 +6,7 @@
 //! `cortex-m0`/`thumbv6m`, you almost certainly want to use the [`cas`] version
 //! of coordination.
 
-#[cfg(feature = "cas-atomics")]
+#[cfg(target_has_atomic = "ptr")]
 pub mod cas;
 
 #[cfg(feature = "critical-section")]

--- a/src/traits/coordination/mod.rs
+++ b/src/traits/coordination/mod.rs
@@ -5,6 +5,8 @@
 //! Unless you are on an embedded target without Compare and Swap atomics, e.g.
 //! `cortex-m0`/`thumbv6m`, you almost certainly want to use the [`cas`] version
 //! of coordination.
+//!
+//! The `cas` module is toggled automatically based on `#[cfg(target_has_atomic = "ptr")]`.
 
 #[cfg(target_has_atomic = "ptr")]
 pub mod cas;


### PR DESCRIPTION
This PR automatically switches CAS based on the target feature, rather than requiring a feature for it.

This avoids intermediate deps needing to also carry a cas-atomics feature flag.