### PR TITLE
Correct logic of Critical Section coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "bbq2"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "const-init",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bbq2"
-version = "0.4.0"
+version = "0.4.1"
 description = "A SPSC, lockless, no_std, thread safe, queue, based on BipBuffers"
 repository = "https://github.com/jamesmunns/bbq2"
 authors = ["James Munns <james@onevariable.com>"]

--- a/src/traits/coordination/cs.rs
+++ b/src/traits/coordination/cs.rs
@@ -76,6 +76,7 @@ unsafe impl Coord for CsCoord {
             if self.write_in_progress.load(Ordering::Relaxed) {
                 return Err(WriteGrantError::GrantInProgress);
             }
+            self.write_in_progress.store(true, Ordering::Relaxed);
 
             // Writer component. Must never write to `read`,
             // be careful writing to `load`
@@ -132,6 +133,7 @@ unsafe impl Coord for CsCoord {
             if self.write_in_progress.load(Ordering::Relaxed) {
                 return Err(WriteGrantError::GrantInProgress);
             }
+            self.write_in_progress.store(true, Ordering::Relaxed);
 
             // Writer component. Must never write to `read`,
             // be careful writing to `load`
@@ -183,6 +185,7 @@ unsafe impl Coord for CsCoord {
             if self.read_in_progress.load(Ordering::Relaxed) {
                 return Err(ReadGrantError::GrantInProgress);
             }
+            self.read_in_progress.store(true, Ordering::Relaxed);
 
             let write = self.write.load(Ordering::Relaxed);
             let last = self.last.load(Ordering::Relaxed);
@@ -287,8 +290,8 @@ unsafe impl Coord for CsCoord {
 
             // This should be fine, purely incrementing
             let old_read = self.read.load(Ordering::Relaxed);
-            self.read.store(used + old_read, Ordering::Release);
-            self.read_in_progress.store(false, Ordering::Release);
+            self.read.store(used + old_read, Ordering::Relaxed);
+            self.read_in_progress.store(false, Ordering::Relaxed);
         })
     }
 }


### PR DESCRIPTION
Previously, we did not mark read/write grants as active. This was both unsound, and also did not work, because when releasing grants, we would notice the grants were not active and then ignore the commit/release.

This was a bad transliteration of CAS to CS.